### PR TITLE
improve developer experience and add some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# vscode generated files
+.vscode-*.*

--- a/generator.js
+++ b/generator.js
@@ -1,3 +1,4 @@
+
 module.exports = api => {
   const isTs = api.entryFile.endsWith('.ts')
   const usesRouter = Boolean(require(api.resolve('package.json')).dependencies['vue-router'])
@@ -6,12 +7,18 @@ module.exports = api => {
     [api.entryFile]: './template/src/main.js'
   }, {
     isTs,
-    usesRouter,
+    usesRouter
   })
 
   api.extendPackage({
+    scripts:{
+      'serve:single-spa':'vue-cli-service serve --mode production'
+    },
     dependencies: {
-      'single-spa-vue': '^1.5.2'
+      'single-spa-vue': '^1.5.2',
+    },
+    devDependencies:{
+      'image-webpack-loader':'^6.0.0'
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = (api, options) => {
   options.css.extract = false
+  options.filenameHashing = false;
 
   api.chainWebpack(webpackConfig => {
     webpackConfig
@@ -9,10 +10,19 @@ module.exports = (api, options) => {
       })
       .set('disableHostCheck', true)
     
+
+    webpackConfig.module.rule()
+        .test(/\.(gif|png|jpe?g|svg)$/i)
+        .use('file-loader')
+        .loader('image-webpack-loader')
+
+
     webpackConfig.optimization.delete('splitChunks')
+    webpackConfig.output.set('chunkFilename','[name].js')
 
     webpackConfig.output.libraryTarget('umd')
 
     webpackConfig.set('devtool', 'sourcemap')
   })
+  
 }

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -1,9 +1,19 @@
 import Vue from 'vue';
-import App from './App.vue';<% if (usesRouter) { %>
-import router from './router';<% } %>
+import App from './App.vue';
+<% if (usesRouter) { %>
+  import router from './router';
+<% } %>
 import singleSpaVue from 'single-spa-vue';
 
+
 Vue.config.productionTip = false;
+const isProd = () => process.env.NODE_ENV === 'production'
+
+if(!isProd()){
+  new Vue({
+    render: h => h(App)
+  }).$mount("#app");
+}
 
 const vueLifecycles = singleSpaVue({
   Vue,


### PR DESCRIPTION
This pull request proposes the following changes:
- In template.js e.g generated main.js determine the development mode e.g development/production and if in development render the app component. This will make it easier for the developer to call yarn serve and start development in his own browser.
- Add 'serve:single-spa' npm script so people can serve the app in --production mode and not render the main "app" component when the script is called
 
It also proposes the following changes in index.js:
- introduce 'image-webpack-loader' so all the images can be packed in the bundle. This also be a risk to bloat the bundle a lot but if we really want a truly independent application the best way on my opinion would be to pack the images within the bundle.
- remove the file name hashing in the output js file